### PR TITLE
Update actions/checkout version to v4

### DIFF
--- a/.github/workflows/TailscaleExitNode.yml
+++ b/.github/workflows/TailscaleExitNode.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Установка Tailscale
       run: |


### PR DESCRIPTION
Перестал работать action, из-за того что Node 16 используемый в actions/checkout@v2 дипрекейтнули:

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/